### PR TITLE
修复微信 8.0.18 密码输入错误

### DIFF
--- a/app/src/main/java/com/surcumference/fingerprint/plugin/WeChatBasePlugin.java
+++ b/app/src/main/java/com/surcumference/fingerprint/plugin/WeChatBasePlugin.java
@@ -261,7 +261,10 @@ public class WeChatBasePlugin {
                         Toast.makeText(context, Lang.getString(R.id.toast_password_not_set_wechat), Toast.LENGTH_SHORT).show();
                         return;
                     }
-                    mInputEditText.setText(pwd);
+                    mInputEditText.getText().clear();
+                    for (char c : pwd.toCharArray()) {
+                        mInputEditText.append(String.valueOf(c));
+                    }
                 });
                 if (titleTextView != null) {
                     titleTextView.setText(Lang.getString(R.id.wechat_payview_fingerprint_title));


### PR DESCRIPTION
微信 8.0.18 可能做了输入字符监听，一次性输入会导致密码错误，改成逐字输入的方式可行